### PR TITLE
Fix server_rec references in mgs_get_ocsp_response()

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -38,6 +38,7 @@ test_scripts = test-00_basic.bash \
 	test-26_redirect_HTTP_to_HTTPS.bash \
 	test-27_OCSP_server.bash \
 	test-28_HTTP2_support.bash \
+	test-29_OCSP_server_no_async.bash \
 	test-30_ip_based_vhosts.bash \
 	test-34_TLS_reverse_proxy_h2.bash \
 	test-35_client_reauth.bash \

--- a/test/data/ocsp.py
+++ b/test/data/ocsp.py
@@ -97,6 +97,9 @@ def handle_post():
             input=req, capture_output=True)
 
         if openssl_run.returncode == 0:
+            print('Sending OCSP response: '
+                  f'\'{base64.b64encode(openssl_run.stdout).decode()}\'',
+                  file=sys.stderr, flush=True)
             stdout_response(HTTPStatus.OK, openssl_run.stdout)
             sys.stderr.buffer.write(openssl_run.stderr)
         else:

--- a/test/tests/29_OCSP_server_no_async/apache.conf
+++ b/test/tests/29_OCSP_server_no_async/apache.conf
@@ -1,0 +1,20 @@
+Include ${srcdir}/base_apache.conf
+GnuTLSCache ${DEFAULT_CACHE}
+
+GnuTLSOCSPAutoRefresh off
+<VirtualHost _default_:${TEST_PORT}>
+	ServerName		test.example.com
+	GnuTLSEnable		On
+	GnuTLSOCSPStapling	Off
+	GnuTLSCertificateFile	authority/server/x509-chain.pem
+	GnuTLSKeyFile		authority/server/secret.key
+</VirtualHost>
+
+<VirtualHost _default_:${TEST_PORT}>
+	ServerName		${TEST_HOST}
+	GnuTLSEnable		On
+	GnuTLSOCSPCacheTimeout	120
+	GnuTLSOCSPFailureTimeout 20
+	GnuTLSCertificateFile	authority/subca/server/x509-chain.pem
+	GnuTLSKeyFile		authority/subca/server/secret.key
+</VirtualHost>

--- a/test/tests/29_OCSP_server_no_async/hooks.py
+++ b/test/tests/29_OCSP_server_no_async/hooks.py
@@ -1,0 +1,15 @@
+import os
+import re
+from mgstest import require_match
+from unittest import SkipTest
+
+
+def prepare_env():
+    if 'OCSP_PORT' not in os.environ:
+        raise SkipTest('OCSP_PORT is not set, check if openssl is available.')
+
+
+def post_check(conn_log, response_log):
+    print('Checking if the client actually got a stapled response:')
+    print(require_match(re.compile(r'^- Options: .*OCSP status request,'),
+                        conn_log).group(0))

--- a/test/tests/29_OCSP_server_no_async/ocsp.conf
+++ b/test/tests/29_OCSP_server_no_async/ocsp.conf
@@ -1,0 +1,1 @@
+Include ${PWD}/ocsp_server.conf

--- a/test/tests/29_OCSP_server_no_async/test.yaml
+++ b/test/tests/29_OCSP_server_no_async/test.yaml
@@ -1,0 +1,17 @@
+!connection
+description: >-
+  Regression test: Sending OCSP requests during handshake incorrectly
+  used the OCSP stapling options of the first virtual host. Check that
+  the problem remains fixed by configuring a first virtual host with
+  stapling disabled and connecting to the second one.
+gnutls_params:
+  - x509cafile=authority/x509.pem
+  - ocsp
+actions:
+  - !request
+    path: /test.txt
+    expect:
+      status: 200
+      body:
+        exactly: |
+          test

--- a/test/tests/Makefile.am
+++ b/test/tests/Makefile.am
@@ -21,6 +21,7 @@ EXTRA_DIST = \
 	26_redirect_HTTP_to_HTTPS/apache.conf 26_redirect_HTTP_to_HTTPS/test.yaml \
 	27_OCSP_server/apache.conf 27_OCSP_server/hooks.py 27_OCSP_server/ocsp.conf 27_OCSP_server/test.yaml \
 	28_HTTP2_support/apache.conf 28_HTTP2_support/hooks.py \
+	29_OCSP_server_no_async/apache.conf 29_OCSP_server_no_async/hooks.py 29_OCSP_server_no_async/ocsp.conf 29_OCSP_server_no_async/test.yaml \
 	30_ip_based_vhosts/apache.conf 30_ip_based_vhosts/hooks.py 30_ip_based_vhosts/test.yaml \
 	34_TLS_reverse_proxy_h2/apache.conf 34_TLS_reverse_proxy_h2/hooks.py 34_TLS_reverse_proxy_h2/backend.conf 34_TLS_reverse_proxy_h2/test.yaml \
 	35_client_reauth/apache.conf 35_client_reauth/test.yaml \


### PR DESCRIPTION
A server_rec reference pointing at the wrong virtual host caused a bug where caching a fresh OCSP response during handshake failed if the initial vhost had OCSP stapling disabled, because with stapling disabled the cache lifetime is set to -1. In other cases a wrong cache lifetime might have been used. See commit eb21e89b97b9b9027da8e633e9c7bfec780c8cab for details including a regression test.