### PR TITLE
Adjust log levels for connection errors

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -13,6 +13,10 @@ on:
       - '!doc/**'
       - '!**.md'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
 
   clang:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,10 @@ on:
       - 'for-debian'
       - 'debian/**'
       - 'pristine-tar'
+
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -11,6 +11,10 @@ on:
       - '**'
       - '!doc/**'
       - '!**.md'
+
+permissions:
+  contents: read
+
 jobs:
   debian-buster:
     runs-on: ubuntu-latest

--- a/src/gnutls_io.c
+++ b/src/gnutls_io.c
@@ -253,7 +253,7 @@ static apr_status_t gnutls_io_input_read(mgs_handle_t * ctxt,
                         (rc == GNUTLS_E_AGAIN ? APR_EAGAIN : APR_EINTR);
             } else if (rc == GNUTLS_E_REHANDSHAKE) {
                 /* A client has asked for a new Hankshake. Currently, we don't do it */
-                ap_log_cerror(APLOG_MARK, APLOG_INFO,
+                ap_log_cerror(APLOG_MARK, APLOG_DEBUG,
                         ctxt->input_rc,
                         ctxt->c,
                         "GnuTLS: Error reading data. Client Requested a New Handshake."
@@ -261,7 +261,7 @@ static apr_status_t gnutls_io_input_read(mgs_handle_t * ctxt,
                         gnutls_strerror(rc));
             } else if (rc == GNUTLS_E_WARNING_ALERT_RECEIVED) {
                 rc = gnutls_alert_get(ctxt->session);
-                ap_log_cerror(APLOG_MARK, APLOG_INFO,
+                ap_log_cerror(APLOG_MARK, APLOG_DEBUG,
                         ctxt->input_rc,
                         ctxt->c,
                         "GnuTLS: Warning Alert From Client: "
@@ -269,7 +269,7 @@ static apr_status_t gnutls_io_input_read(mgs_handle_t * ctxt,
                         gnutls_alert_get_name(rc));
             } else if (rc == GNUTLS_E_FATAL_ALERT_RECEIVED) {
                 rc = gnutls_alert_get(ctxt->session);
-                ap_log_cerror(APLOG_MARK, APLOG_INFO,
+                ap_log_cerror(APLOG_MARK, APLOG_DEBUG,
                         ctxt->input_rc,
                         ctxt->c,
                         "GnuTLS: Fatal Alert From Client: "
@@ -280,13 +280,12 @@ static apr_status_t gnutls_io_input_read(mgs_handle_t * ctxt,
             } else {
                 /* Some Other Error. Report it. Die. */
                 if (gnutls_error_is_fatal(rc)) {
-                    ap_log_cerror(APLOG_MARK,
-                            APLOG_INFO,
-                            ctxt->input_rc,
-                            ctxt->c,
-                            "GnuTLS: Error reading data. (%d) '%s'",
-                            rc,
-                            gnutls_strerror(rc));
+                    ap_log_cerror(
+                        APLOG_MARK, APLOG_DEBUG,
+                        ctxt->input_rc,
+                        ctxt->c,
+                        "GnuTLS: Error reading data. (%d) '%s'",
+                        rc, gnutls_strerror(rc));
                 } else if (*len > 0) {
                     ctxt->input_rc = APR_SUCCESS;
                     break;

--- a/src/gnutls_io.c
+++ b/src/gnutls_io.c
@@ -777,7 +777,7 @@ apr_status_t mgs_filter_output(ap_filter_t * f, apr_bucket_brigade * bb) {
 
                 if (ret < 0) {
                     /* error sending output */
-                    ap_log_cerror(APLOG_MARK, APLOG_INFO, ctxt->output_rc,
+                    ap_log_cerror(APLOG_MARK, APLOG_DEBUG, ctxt->output_rc,
                                   ctxt->c,
                                   "GnuTLS: Error writing data. (%d) '%s'",
                                   ret, gnutls_strerror(ret));


### PR DESCRIPTION
Error conditions for aborted connections occur in normal operation and don't need a log level more urgent than "debug".