### PR TITLE
CI: Update Fedora image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         container:
           - 'debian:bullseye'
           - 'debian:sid'
-          - 'fedora:35'
+          - 'fedora:37'
           - 'alpine:latest'
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}


### PR DESCRIPTION
Fedora 37 is the current "latest".