### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: cppcheck
         run: |
           cppcheck --project=compile_commands.json -DAF_UNIX=1 --enable=warning,style,unusedFunction --xml 2>cppcheck.xml
-      - uses: airtower-luna/convert-to-sarif@v1.0.1
+      - uses: airtower-luna/convert-to-sarif@v1.0.2
         with:
           tool: 'CppCheck'
           input_file: 'cppcheck.xml'

--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
 
   clang:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: debian:bullseye
     name: clang-analyzer
     steps:
@@ -58,7 +58,7 @@ jobs:
           checkout_path: ${{ env.CONTAINER_WORKSPACE }}
 
   cppcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: debian:bullseye
     name: cppcheck
     steps:
@@ -92,7 +92,7 @@ jobs:
           checkout_path: ${{ env.CONTAINER_WORKSPACE }}
 
   codeql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: CodeQL
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - 'debian:bullseye'
+          - 'debian:bookworm'
           - 'debian:sid'
-          - 'fedora:37'
+          - 'fedora:38'
           - 'alpine:latest'
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
@@ -56,7 +56,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    container: debian:bullseye
+    container: debian:bookworm
     name: coverage
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,9 @@ jobs:
         uses: ./.github/build-action/
         with:
           cc: clang
-          configure-options: --enable-clang-coverage
+          configure-options: >-
+            --enable-clang-coverage
+            CFLAGS="-Wno-null-pointer-subtraction"
           artifact-prefix: coverage
       - name: generate coverage report
         working-directory: ./test

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -17,9 +17,9 @@ permissions:
   contents: read
 
 jobs:
-  debian-bullseye:
+  debian-bookworm:
     runs-on: ubuntu-latest
-    container: debian:bullseye
+    container: debian:bookworm
     steps:
       - uses: actions/checkout@v3
       - name: install dependencies

--- a/test/suppressions.valgrind
+++ b/test/suppressions.valgrind
@@ -24,6 +24,7 @@
    Memcheck:Leak
    match-leak-kinds: possible
    fun:calloc
+   fun:calloc
    fun:allocate_dtv
    fun:_dl_allocate_tls
    fun:allocate_stack


### PR DESCRIPTION
* Update airtower-luna/convert-to-sarif to v1.0.2
* Update analysis jobs to use ubuntu-22.04
* Use Debian Bookworm & Fedora 38 for CI builds, plus compatibility adjustments.