### PR TITLE
Explicitly define build process for CodeQL analysis

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -21,14 +21,14 @@ jobs:
 
   clang:
     runs-on: ubuntu-22.04
-    container: debian:bullseye
+    container: debian:bookworm
     name: clang-analyzer
     steps:
       - name: install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get -y install git python3-yaml apache2-bin apache2-dev gnutls-bin libapr1-dev libgnutls28-dev pkg-config procps clang clang-tools libmsv-dev
+          apt-get -y install git python3-yaml apache2-bin apache2-dev gnutls-bin libapr1-dev libgnutls28-dev pkgconf procps clang clang-tools libmsv-dev
       - uses: actions/checkout@v4
       - name: find usable IPs for tests
         run: |
@@ -59,14 +59,14 @@ jobs:
 
   cppcheck:
     runs-on: ubuntu-22.04
-    container: debian:bullseye
+    container: debian:bookworm
     name: cppcheck
     steps:
       - name: install dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get -y install git python3-yaml apache2-bin apache2-dev gnutls-bin libapr1-dev libgnutls28-dev libmsv-dev pkg-config procps bear cppcheck
+          apt-get -y install git python3-yaml apache2-bin apache2-dev gnutls-bin libapr1-dev libgnutls28-dev libmsv-dev pkgconf procps bear cppcheck
       - uses: actions/checkout@v4
       - name: autoreconf
         run: autoreconf -fiv
@@ -99,7 +99,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install python3-yaml apache2-bin apache2-dev gnutls-bin libapr1-dev libgnutls28-dev libmsv-dev pkg-config procps
+          sudo apt-get -y install python3-yaml apache2-bin apache2-dev gnutls-bin libapr1-dev libgnutls28-dev libmsv-dev pkgconf procps
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: autoreconf
         run: autoreconf -fiv
       - name: configure
-        run: scan-build --use-cc=clang ./configure --enable-msva TEST_IP="${test_ips}" APACHE_MUTEX=pthread
+        run: scan-build --use-cc=clang ./configure --enable-msva TEST_IP="${test_ips}" APACHE_MUTEX=pthread CFLAGS=-Wno-error=null-pointer-subtraction
       - name: store config.log
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -104,7 +104,11 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: cpp
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - name: autoreconf
+        run: autoreconf -fiv
+      - name: configure
+        run: ./configure --disable-pdf-doc
+      - name: make
+        run: make -j4
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
The build on a Dependabot branch failed because the automatic build installed Pandoc, which made the build try to build PDF documentation, but some LaTeX components were missing. There's no point in building documentation at all during this workflow.

Plus general dependency updates in the analysis builds.