### PR TITLE
CI: set category for clang-analyzer and cppcheck SARIF uploads

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -56,6 +56,7 @@ jobs:
         with:
           sarif_file: ${{ env.SARIF_DIR }}
           checkout_path: ${{ env.CONTAINER_WORKSPACE }}
+          category: clang-analyzer
 
   cppcheck:
     runs-on: ubuntu-22.04
@@ -90,6 +91,7 @@ jobs:
         with:
           sarif_file: 'cppcheck.sarif'
           checkout_path: ${{ env.CONTAINER_WORKSPACE }}
+          category: cppcheck
 
   codeql:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
New Github requirement, see:
https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/