### PR TITLE
Header cleanup

### DIFF
--- a/include/mod_gnutls.h.in
+++ b/include/mod_gnutls.h.in
@@ -19,7 +19,6 @@
 /* Apache Runtime Headers */
 #include "httpd.h"
 #include "http_config.h"
-#include "http_log.h"
 #include "apr_buckets.h"
 #include "apr_optional.h"
 #include "apr_portable.h"

--- a/include/mod_gnutls.h.in
+++ b/include/mod_gnutls.h.in
@@ -19,12 +19,13 @@
 /* Apache Runtime Headers */
 #include "httpd.h"
 #include "http_config.h"
-#include "http_core.h"
 #include "http_log.h"
 #include "apr_buckets.h"
+#include "apr_optional.h"
 #include "apr_portable.h"
 #include "apr_tables.h"
 #include "ap_release.h"
+#include <util_filter.h>
 /* GnuTLS Library Headers */
 #include <gnutls/gnutls.h>
 #include <gnutls/abstract.h>

--- a/include/mod_gnutls.h.in
+++ b/include/mod_gnutls.h.in
@@ -1,7 +1,7 @@
 /*
  *  Copyright 2004-2005 Paul Querna
  *  Copyright 2014 Nikos Mavrogiannopoulos
- *  Copyright 2015-2020 Fiona Klute
+ *  Copyright 2015-2026 Fiona Klute
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -277,64 +277,6 @@ const char *mgs_set_proxy_engine(cmd_parms * parms, void *dummy,
 apr_status_t mgs_cleanup_pre_config(void *data);
 
 
-
-/**
- * Perform any reinitialization required in PKCS #11
- */
-int mgs_pkcs11_reinit(server_rec * s);
-
-
-
-/* Configuration Functions */
-
-/* Loads all files set in the configuration */
-int mgs_load_files(apr_pool_t *pconf, apr_pool_t *ptemp, server_rec *s)
-    __attribute__((nonnull));
-
-const char *mgs_set_dh_file(cmd_parms * parms, void *dummy,
-                                        const char *arg);
-const char *mgs_set_cert_file(cmd_parms * parms, void *dummy,
-                                        const char *arg);
-
-const char *mgs_set_key_file(cmd_parms * parms, void *dummy,
-                             const char *arg);
-
-const char *mgs_set_timeout(cmd_parms *parms, void *dummy, const char *arg);
-
-const char *mgs_set_client_verify(cmd_parms * parms, void *dummy,
-                                  const char *arg);
-
-const char *mgs_set_client_ca_file(cmd_parms * parms, void *dummy,
-                                   const char *arg);
-
-const char *mgs_set_p11_module(cmd_parms * parms, void *dummy,
-                               const char *arg);
-
-const char *mgs_set_pin(cmd_parms * parms, void *dummy,
-                                   const char *arg);
-
-const char *mgs_set_srk_pin(cmd_parms * parms, void *dummy,
-                                   const char *arg);
-
-const char *mgs_set_enabled(cmd_parms * parms, void *dummy,
-                            const int arg);
-const char *mgs_set_export_certificates_size(cmd_parms * parms, void *dummy,
-                            const char *arg);
-const char *mgs_set_priorities(cmd_parms * parms, void *dummy,
-                            const char *arg);
-const char *mgs_set_tickets(cmd_parms * parms, void *dummy,
-                            const int arg);
-
-void *mgs_config_server_create(apr_pool_t * p, server_rec * s);
-void *mgs_config_server_merge(apr_pool_t *p, void *BASE, void *ADD);
-
-void *mgs_config_dir_merge(apr_pool_t *p, void *basev, void *addv);
-
-void *mgs_config_dir_create(apr_pool_t *p, char *dir);
-
-const char *mgs_store_cred_path(cmd_parms * parms,
-                                void *dummy __attribute__((unused)),
-                                const char *arg);
 
 /* mod_gnutls Hooks. */
 

--- a/include/mod_gnutls.h.in
+++ b/include/mod_gnutls.h.in
@@ -17,13 +17,12 @@
  */
 
 /* Apache Runtime Headers */
-#include "httpd.h"
-#include "http_config.h"
-#include "apr_buckets.h"
-#include "apr_optional.h"
-#include "apr_portable.h"
-#include "apr_tables.h"
-#include "ap_release.h"
+#include <httpd.h>
+#include <http_config.h>
+#include <apr_buckets.h>
+#include <apr_optional.h>
+#include <apr_portable.h>
+#include <apr_tables.h>
 #include <util_filter.h>
 /* GnuTLS Library Headers */
 #include <gnutls/gnutls.h>

--- a/include/mod_gnutls.h.in
+++ b/include/mod_gnutls.h.in
@@ -19,7 +19,6 @@
 /* Apache Runtime Headers */
 #include "httpd.h"
 #include "http_config.h"
-#include "http_request.h"
 #include "http_core.h"
 #include "http_log.h"
 #include "apr_buckets.h"

--- a/include/mod_gnutls.h.in
+++ b/include/mod_gnutls.h.in
@@ -19,12 +19,12 @@
 /* Apache Runtime Headers */
 #include "httpd.h"
 #include "http_config.h"
-#include "http_protocol.h"
 #include "http_connection.h"
 #include "http_request.h"
 #include "http_core.h"
 #include "http_log.h"
 #include "apr_buckets.h"
+#include "apr_portable.h"
 #include "apr_tables.h"
 #include "ap_release.h"
 /* GnuTLS Library Headers */

--- a/include/mod_gnutls.h.in
+++ b/include/mod_gnutls.h.in
@@ -19,7 +19,6 @@
 /* Apache Runtime Headers */
 #include "httpd.h"
 #include "http_config.h"
-#include "http_connection.h"
 #include "http_request.h"
 #include "http_core.h"
 #include "http_log.h"

--- a/src/gnutls_cache.c
+++ b/src/gnutls_cache.c
@@ -32,6 +32,7 @@
 #include "gnutls_config.h"
 #include "gnutls_ocsp.h"
 
+#include <http_protocol.h>
 #include <ap_socache.h>
 #include <apr_strings.h>
 #include <mod_status.h>

--- a/src/gnutls_cache.c
+++ b/src/gnutls_cache.c
@@ -32,6 +32,7 @@
 #include "gnutls_config.h"
 #include "gnutls_ocsp.h"
 
+#include <http_log.h>
 #include <http_protocol.h>
 #include <ap_socache.h>
 #include <apr_strings.h>

--- a/src/gnutls_config.c
+++ b/src/gnutls_config.c
@@ -21,9 +21,10 @@
 #include "gnutls_config.h"
 #include "mod_gnutls.h"
 
-#include "apr_lib.h"
+#include <apr_lib.h>
 #include <apr_strings.h>
 #include <gnutls/abstract.h>
+#include <http_log.h>
 
 #define INIT_CA_SIZE 128
 

--- a/src/gnutls_config.h
+++ b/src/gnutls_config.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016-2018 Fiona Klute
+ *  Copyright 2016-2026 Fiona Klute
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -23,13 +23,64 @@
 /* timeouts as defined in mgs_set_timeout() cannot be negative */
 #define MGS_TIMEOUT_UNSET -1
 
-/* TODO: move configuration related function definitions from
- * mod_gnutls.h.in over here */
+/**
+ * Perform any reinitialization required in PKCS #11
+ */
+int mgs_pkcs11_reinit(server_rec * s);
 
-const char *mgs_set_cache(cmd_parms * parms, void *dummy,
-                          const char *type, const char* arg);
+/* Loads all files set in the configuration */
+int mgs_load_files(apr_pool_t *pconf, apr_pool_t *ptemp, server_rec *s)
+    __attribute__((nonnull));
+
+const char *mgs_set_dh_file(cmd_parms * parms, void *dummy,
+                                        const char *arg);
+const char *mgs_set_cert_file(cmd_parms * parms, void *dummy,
+                                        const char *arg);
+
+const char *mgs_set_key_file(cmd_parms * parms, void *dummy,
+                             const char *arg);
+
+const char *mgs_set_timeout(cmd_parms *parms, void *dummy, const char *arg);
+
+const char *mgs_set_client_verify(cmd_parms * parms, void *dummy,
+                                  const char *arg);
+
+const char *mgs_set_client_ca_file(cmd_parms * parms, void *dummy,
+                                   const char *arg);
 
 const char *mgs_set_client_key_purpose(cmd_parms * parms, void *dummy,
                                        const char *arg);
+
+const char *mgs_set_p11_module(cmd_parms * parms, void *dummy,
+                               const char *arg);
+
+const char *mgs_set_pin(cmd_parms * parms, void *dummy,
+                                   const char *arg);
+
+const char *mgs_set_srk_pin(cmd_parms * parms, void *dummy,
+                                   const char *arg);
+
+const char *mgs_set_enabled(cmd_parms * parms, void *dummy,
+                            const int arg);
+const char *mgs_set_export_certificates_size(cmd_parms * parms, void *dummy,
+                            const char *arg);
+const char *mgs_set_priorities(cmd_parms * parms, void *dummy,
+                            const char *arg);
+const char *mgs_set_tickets(cmd_parms * parms, void *dummy,
+                            const int arg);
+
+void *mgs_config_server_create(apr_pool_t * p, server_rec * s);
+void *mgs_config_server_merge(apr_pool_t *p, void *BASE, void *ADD);
+
+void *mgs_config_dir_merge(apr_pool_t *p, void *basev, void *addv);
+
+void *mgs_config_dir_create(apr_pool_t *p, char *dir);
+
+const char *mgs_store_cred_path(cmd_parms * parms,
+                                void *dummy __attribute__((unused)),
+                                const char *arg);
+
+const char *mgs_set_cache(cmd_parms * parms, void *dummy,
+                          const char *type, const char* arg);
 
 #endif /* __MOD_GNUTLS_CONFIG_H__ */

--- a/src/gnutls_hooks.c
+++ b/src/gnutls_hooks.c
@@ -28,7 +28,8 @@
 #include "gnutls_util.h"
 #include "gnutls_watchdog.h"
 
-#include "http_vhost.h"
+#include <http_protocol.h>
+#include <http_vhost.h>
 #include <mod_status.h>
 #include <util_mutex.h>
 #include <apr_escape.h>

--- a/src/gnutls_io.c
+++ b/src/gnutls_io.c
@@ -21,6 +21,8 @@
 #include "gnutls_io.h"
 #include "gnutls_proxy.h"
 
+#include <http_connection.h>
+
 #ifdef APLOG_USE_MODULE
 APLOG_USE_MODULE(gnutls);
 #endif

--- a/src/gnutls_io.c
+++ b/src/gnutls_io.c
@@ -22,6 +22,7 @@
 #include "gnutls_proxy.h"
 
 #include <http_connection.h>
+#include <http_core.h>
 
 #ifdef APLOG_USE_MODULE
 APLOG_USE_MODULE(gnutls);

--- a/src/gnutls_io.c
+++ b/src/gnutls_io.c
@@ -23,6 +23,7 @@
 
 #include <http_connection.h>
 #include <http_core.h>
+#include <http_log.h>
 
 #ifdef APLOG_USE_MODULE
 APLOG_USE_MODULE(gnutls);

--- a/src/gnutls_proxy.c
+++ b/src/gnutls_proxy.c
@@ -21,6 +21,7 @@
 
 #include <apr_strings.h>
 #include <gnutls/gnutls.h>
+#include <http_log.h>
 
 APLOG_USE_MODULE(gnutls);
 

--- a/src/gnutls_sni.c
+++ b/src/gnutls_sni.c
@@ -18,6 +18,7 @@
 
 #include <apr_lib.h>
 #include <apr_strings.h>
+#include <http_log.h>
 #include <byteswap.h>
 #include <gnutls/gnutls.h>
 #include <inttypes.h>

--- a/src/mod_gnutls.c
+++ b/src/mod_gnutls.c
@@ -24,6 +24,7 @@
 #include "gnutls_util.h"
 
 #include <apr_strings.h>
+#include <http_connection.h>
 #include <http_protocol.h>
 
 #ifdef APLOG_USE_MODULE

--- a/src/mod_gnutls.c
+++ b/src/mod_gnutls.c
@@ -25,6 +25,7 @@
 
 #include <apr_strings.h>
 #include <http_connection.h>
+#include <http_log.h>
 #include <http_protocol.h>
 #include <http_request.h>
 

--- a/src/mod_gnutls.c
+++ b/src/mod_gnutls.c
@@ -26,6 +26,7 @@
 #include <apr_strings.h>
 #include <http_connection.h>
 #include <http_protocol.h>
+#include <http_request.h>
 
 #ifdef APLOG_USE_MODULE
 APLOG_USE_MODULE(gnutls);

--- a/src/mod_gnutls.c
+++ b/src/mod_gnutls.c
@@ -24,6 +24,7 @@
 #include "gnutls_util.h"
 
 #include <apr_strings.h>
+#include <http_protocol.h>
 
 #ifdef APLOG_USE_MODULE
 APLOG_USE_MODULE(gnutls);


### PR DESCRIPTION
* Move config function declarations from `mod_gnutls.h.in` to `gnutls_config.h`
* Move includes not needed in `mod_gnutls.h.in` to where they are used
* Consistently use `#include <...>` for external headers