### PR TITLE
Search HTTPD binary for tests only in PATH, add override

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+** Version 0.13.1 (UNRELEASED)
+
+- Add "httpd-bin" build option to select httpd binary to use in
+  tests. Search without PATH modifications otherwise.
+
 ** Version 0.13.0 (2026-03-20)
 
 - Security fix (CVE-2026-33307): Fix out-of-bounds write when

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('mod_gnutls', 'c',
-	version: '0.13.0',
+	version: '0.13.1',
 	meson_version: '>=1.1',
 	license: 'Apache-2.0',
 	# enable when all CI jobs use Meson >= 1.1 (Trixie release)
@@ -39,7 +39,7 @@ if pandoc.found()
     pandoc, '--version', check: true, capture: true).stdout().split()[1]
   message('Found Pandoc version:', pandoc_version)
 endif
-httpd = find_program('apache2', 'httpd', dirs: ['/usr/sbin'], required: true)
+httpd = find_program(get_option('httpd-bin'), 'apache2', 'httpd', required: true)
 
 incdir = include_directories('include')
 subdir('include')

--- a/meson.options
+++ b/meson.options
@@ -3,6 +3,7 @@ option('gnutls-debug-log', type: 'boolean', value: false,
 option('pdf-doc', type: 'boolean', value: true,
        description: 'build PDF documentation')
 option('apxs-bin', type: 'string', value: 'apxs', description: 'path to apxs')
+option('httpd-bin', type: 'string', description: 'path to httpd binary to use for tests, default is to search "httpd" and "apache2" in PATH')
 
 option('test-host', type: 'string', value: 'localhost',
        description: 'server hostname to use in tests, must resolve to test-ips')


### PR DESCRIPTION
Prepending `/usr/sbin` to the search path causes trouble where a matching binary exists there, but another one on `PATH` should be used. Additionally selecting the binary independently of PATH may be desirable, which is already possible for `apxs`.

The new `httpd-bin` build option can be set to a full path to select the binary, search without `PATH` modifications otherwise.